### PR TITLE
Adding goswagger annotations to VersionNumber strings

### DIFF
--- a/types/module/version_number.go
+++ b/types/module/version_number.go
@@ -18,6 +18,8 @@ const maxVersionLength = 255
 // VersionNumber describes the semver version number. Note that in contrast to provider versions module versions
 // do not have a compulsory "v" prefix. Call ToVCSVersion() before you call Normalize() in order to get the correct
 // VCS version.
+//
+// swagger:model ModuleVersionNumber
 type VersionNumber string
 
 // Normalize adds a "v" prefix if none is present. Note, however, that in contrast to provider versions module versions

--- a/types/provider/version_number.go
+++ b/types/provider/version_number.go
@@ -16,6 +16,8 @@ var versionRe = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(|-[a-zA-Z0-9-.]+)$`
 const maxVersionLength = 255
 
 // VersionNumber describes the semver version number.
+//
+// swagger:model ProviderVersionNumber
 type VersionNumber string
 
 func (v VersionNumber) Normalize() VersionNumber {


### PR DESCRIPTION
This PR adds goswagger annotations to differentiate between `model.VersionNumber` and `provider.VersionNumber`.